### PR TITLE
[#11] 도형 생성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 # Editor directories and files
+.cursor/*
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-icons": "^5.4.0"
+        "react-icons": "^5.4.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -1334,13 +1335,13 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1945,7 +1946,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -3995,6 +3996,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.4.0"
+    "react-icons": "^5.4.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -156,7 +156,7 @@ export const EditorCanvas = ({
       rotation: 0,
     };
 
-    let shape: Shape;
+    let shape: Shape | null = null;
 
     switch (selectedTool) {
       case "rectangle":
@@ -186,11 +186,10 @@ export const EditorCanvas = ({
         break;
 
       default:
-        endDrawing();
-        return;
+        break;
     }
 
-    addShape(shape);
+    if (shape) addShape(shape);
     endDrawing();
   }, [
     resize.isResizing,

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -9,22 +9,11 @@ import {
   RectangleShape,
   Shape,
 } from "@/types/shape";
-import { Circle } from "./shapes/Circle";
-import { Polygon } from "./shapes/Polygon";
-import { Rectangle } from "./shapes/Rectangle";
+
 import { calculateShapeDimensions } from "@/utils/shapeCalculator";
 import { Preview } from "./Preview";
 import { Selection } from "./Selection";
-import { isPointInShape } from "@/utils/shapeHelpers";
-
-const ShapeComponents: Record<
-  Shape["type"],
-  React.ComponentType<{ shape: Shape }>
-> = {
-  rectangle: Rectangle as React.ComponentType<{ shape: Shape }>,
-  circle: Circle as React.ComponentType<{ shape: Shape }>,
-  polygon: Polygon as React.ComponentType<{ shape: Shape }>,
-};
+import { isPointInShape, shapeComponentsMapper } from "@/utils/shapeHelpers";
 
 export const EditorCanvas = ({
   width,
@@ -214,7 +203,7 @@ export const EditorCanvas = ({
   );
 
   const renderShape = (shape: Shape) => {
-    const Component = ShapeComponents[shape.type];
+    const Component = shapeComponentsMapper[shape.type];
     return <Component key={shape.id} shape={shape} />;
   };
 

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -3,11 +3,17 @@ import { CanvasProps } from "@/types/components/canvas";
 import { useEditorStore } from "@/store/useEditorStore";
 import { Point } from "@/types/mouse";
 
-import { Shape } from "@/types/shape";
+import {
+  CircleShape,
+  PolygonShape,
+  RectangleShape,
+  Shape,
+} from "@/types/shape";
 import { Circle } from "./shapes/Circle";
 import { Polygon } from "./shapes/Polygon";
 import { Rectangle } from "./shapes/Rectangle";
 import { calculateShapeDimensions } from "@/utils/shapeCalculator";
+import { Preview } from "./Preview";
 
 const ShapeComponents: Record<
   Shape["type"],
@@ -76,17 +82,49 @@ export const EditorCanvas = ({
       type: selectedTool,
     });
 
-    addShape({
+    const baseShape = {
       type: selectedTool,
-      ...dimensions,
-      styles: {
-        fill: "#000",
-        stroke: "#000000",
-        strokeWidth: 1,
-        rotation: 0,
-      },
-    });
+      fill: "#000",
+      stroke: "#000000",
+      strokeWidth: 1,
+      rotation: 0,
+    };
 
+    let shape: Shape;
+
+    switch (selectedTool) {
+      case "rectangle":
+        shape = {
+          ...baseShape,
+          type: "rectangle",
+          borderRadius: 0,
+          ...dimensions,
+        } as RectangleShape;
+        break;
+
+      case "circle":
+        shape = {
+          ...baseShape,
+          type: "circle",
+          ...dimensions,
+        } as CircleShape;
+        break;
+
+      case "polygon":
+        shape = {
+          ...baseShape,
+          type: "polygon",
+          sides: 3,
+          ...dimensions,
+        } as PolygonShape;
+        break;
+
+      default:
+        endDrawing();
+        return;
+    }
+
+    addShape(shape);
     endDrawing();
   }, [mouse, selectedTool, addShape, endDrawing]);
 
@@ -114,6 +152,7 @@ export const EditorCanvas = ({
     >
       <svg width={width} height={height}>
         {shapes.map(renderShape)}
+        <Preview renderShape={renderShape} />
       </svg>
     </div>
   );

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -3,12 +3,26 @@ import { CanvasProps } from "@/types/components/canvas";
 import { useEditorStore } from "@/store/useEditorStore";
 import { Point } from "@/types/mouse";
 
+import { Shape } from "@/types/shape";
+import { Circle } from "./shapes/Circle";
+import { Polygon } from "./shapes/Polygon";
+import { Rectangle } from "./shapes/Rectangle";
+
+const ShapeComponents: Record<
+  Shape["type"],
+  React.ComponentType<{ shape: Shape }>
+> = {
+  rectangle: Rectangle as React.ComponentType<{ shape: Shape }>,
+  circle: Circle as React.ComponentType<{ shape: Shape }>,
+  polygon: Polygon as React.ComponentType<{ shape: Shape }>,
+};
+
 export const EditorCanvas = ({
   width,
   height,
   backgroundColor,
 }: CanvasProps) => {
-  const { startDrawing, updateDrawing, endDrawing } = useEditorStore();
+  const { shapes, startDrawing, updateDrawing, endDrawing } = useEditorStore();
 
   const getCanvasPoint = useCallback((e: React.MouseEvent): Point => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -38,6 +52,11 @@ export const EditorCanvas = ({
     endDrawing();
   }, [endDrawing]);
 
+  const renderShape = (shape: Shape) => {
+    const Component = ShapeComponents[shape.type];
+    return <Component key={shape.id} shape={shape} />;
+  };
+
   if (!width || !height) {
     return null;
   }
@@ -55,7 +74,9 @@ export const EditorCanvas = ({
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
-      {/* SVG 요소 추가 */}
+      <svg width={width} height={height}>
+        {shapes.map(renderShape)}
+      </svg>
     </div>
   );
 };

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -1,10 +1,43 @@
+import { useCallback } from "react";
 import { CanvasProps } from "@/types/components/canvas";
+import { useEditorStore } from "@/store/useEditorStore";
+import { Point } from "@/types/mouse";
 
 export const EditorCanvas = ({
   width,
   height,
   backgroundColor,
 }: CanvasProps) => {
+  const { startDrawing, updateDrawing, endDrawing } = useEditorStore();
+
+  const getCanvasPoint = useCallback((e: React.MouseEvent): Point => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    return {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+  }, []);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      const point = getCanvasPoint(e);
+      startDrawing(point);
+    },
+    [startDrawing, getCanvasPoint]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const point = getCanvasPoint(e);
+      updateDrawing(point);
+    },
+    [updateDrawing, getCanvasPoint]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    endDrawing();
+  }, [endDrawing]);
+
   if (!width || !height) {
     return null;
   }
@@ -17,6 +50,10 @@ export const EditorCanvas = ({
         height: `${height}px`,
         backgroundColor,
       }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
     >
       {/* SVG 요소 추가 */}
     </div>

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -145,40 +145,28 @@ export const EditorCanvas = ({
       rotation: 0,
     };
 
-    let shape: Shape | null = null;
-
-    switch (selectedTool) {
-      case "rectangle":
-        shape = {
+    const shape = () =>
+      ({
+        rectangle: {
           ...baseShape,
-          type: "rectangle",
+          type: "rectangle" as const,
           borderRadius: 0,
           ...dimensions,
-        } as RectangleShape;
-        break;
-
-      case "circle":
-        shape = {
+        } as RectangleShape,
+        circle: {
           ...baseShape,
-          type: "circle",
+          type: "circle" as const,
           ...dimensions,
-        } as CircleShape;
-        break;
-
-      case "polygon":
-        shape = {
+        } as CircleShape,
+        polygon: {
           ...baseShape,
-          type: "polygon",
+          type: "polygon" as const,
           sides: 3,
           ...dimensions,
-        } as PolygonShape;
-        break;
+        } as PolygonShape,
+      }[selectedTool] ?? null);
 
-      default:
-        break;
-    }
-
-    if (shape) addShape(shape);
+    if (!shape) addShape(shape);
     endDrawing();
   }, [
     resize.isResizing,

--- a/src/pages/Editor/components/Canvas/EditorCanvas.tsx
+++ b/src/pages/Editor/components/Canvas/EditorCanvas.tsx
@@ -145,8 +145,8 @@ export const EditorCanvas = ({
       rotation: 0,
     };
 
-    const shape = () =>
-      ({
+    const newShape =
+      {
         rectangle: {
           ...baseShape,
           type: "rectangle" as const,
@@ -164,9 +164,9 @@ export const EditorCanvas = ({
           sides: 3,
           ...dimensions,
         } as PolygonShape,
-      }[selectedTool] ?? null);
+      }[selectedTool] ?? null;
 
-    if (!shape) addShape(shape);
+    if (newShape) addShape(newShape);
     endDrawing();
   }, [
     resize.isResizing,

--- a/src/pages/Editor/components/Canvas/Preview.tsx
+++ b/src/pages/Editor/components/Canvas/Preview.tsx
@@ -1,0 +1,71 @@
+import { useEditorStore } from "@/store/useEditorStore";
+import { calculateShapeDimensions } from "@/utils/shapeCalculator";
+import {
+  Shape,
+  RectangleShape,
+  CircleShape,
+  PolygonShape,
+} from "@/types/shape";
+
+interface PreviewProps {
+  renderShape: (shape: Shape) => JSX.Element;
+}
+
+export const Preview = ({ renderShape }: PreviewProps) => {
+  const { mouse, selectedTool } = useEditorStore();
+  const { isDrawing, startPoint, endPoint } = mouse;
+
+  if (!isDrawing || !startPoint || !endPoint || selectedTool === "cursor") {
+    return null;
+  }
+
+  const dimensions = calculateShapeDimensions({
+    startPoint,
+    endPoint,
+    type: selectedTool,
+  });
+
+  const baseShape = {
+    id: "preview",
+    type: selectedTool,
+    fill: "none",
+    stroke: "#000000",
+    strokeWidth: 1,
+    rotation: 0,
+  };
+
+  let previewShape: Shape;
+
+  switch (selectedTool) {
+    case "rectangle":
+      previewShape = {
+        ...baseShape,
+        type: "rectangle",
+        borderRadius: 0,
+        ...dimensions,
+      } as RectangleShape;
+      break;
+
+    case "circle":
+      previewShape = {
+        ...baseShape,
+        type: "circle",
+        ...dimensions,
+      } as CircleShape;
+      break;
+
+    case "polygon":
+      previewShape = {
+        ...baseShape,
+        type: "polygon",
+        sides: 3,
+        ...dimensions,
+      } as PolygonShape;
+      break;
+
+    default:
+      return null;
+  }
+
+  return renderShape(previewShape);
+};

--- a/src/pages/Editor/components/Canvas/Preview.tsx
+++ b/src/pages/Editor/components/Canvas/Preview.tsx
@@ -34,38 +34,27 @@ export const Preview = ({ renderShape }: PreviewProps) => {
     rotation: 0,
   };
 
-  let previewShape: Shape;
-
-  switch (selectedTool) {
-    case "rectangle":
-      previewShape = {
+  const previewShape =
+    {
+      rectangle: {
         ...baseShape,
-        type: "rectangle",
+        type: "rectangle" as const,
         borderRadius: 0,
         ...dimensions,
-      } as RectangleShape;
-      break;
-
-    case "circle":
-      previewShape = {
+      } as RectangleShape,
+      circle: {
         ...baseShape,
-        type: "circle",
+        type: "circle" as const,
         ...dimensions,
-      } as CircleShape;
-      break;
-
-    case "polygon":
-      previewShape = {
+      } as CircleShape,
+      polygon: {
         ...baseShape,
-        type: "polygon",
+        type: "polygon" as const,
         sides: 3,
         ...dimensions,
-      } as PolygonShape;
-      break;
+      } as PolygonShape,
+    }[selectedTool] ?? null;
 
-    default:
-      return null;
-  }
-
+  if (!previewShape) return null;
   return renderShape(previewShape);
 };

--- a/src/pages/Editor/components/Canvas/Selection.tsx
+++ b/src/pages/Editor/components/Canvas/Selection.tsx
@@ -7,6 +7,7 @@ interface SelectionProps {
 }
 
 const HANDLE_SIZE = 8;
+const ROTATE_HANDLE_OFFSET = 20;
 
 export const Selection = ({ shape, onStartResize }: SelectionProps) => {
   const getBoundingBox = () => {
@@ -47,6 +48,10 @@ export const Selection = ({ shape, onStartResize }: SelectionProps) => {
     onStartResize(handle, point);
   };
 
+  const handleRotateMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   const renderHandle = (position: string, x: number, y: number) => (
     <rect
       x={x - HANDLE_SIZE / 2}
@@ -78,6 +83,25 @@ export const Selection = ({ shape, onStartResize }: SelectionProps) => {
       {renderHandle("ne", box.x + box.width, box.y)}
       {renderHandle("se", box.x + box.width, box.y + box.height)}
       {renderHandle("sw", box.x, box.y + box.height)}
+
+      <line
+        x1={box.x + box.width / 2}
+        y1={box.y}
+        x2={box.x + box.width / 2}
+        y2={box.y - ROTATE_HANDLE_OFFSET}
+        stroke="#0B7FFF"
+        strokeWidth={1}
+      />
+      <circle
+        cx={box.x + box.width / 2}
+        cy={box.y - ROTATE_HANDLE_OFFSET}
+        r={4}
+        fill="white"
+        stroke="#0B7FFF"
+        strokeWidth={1}
+        style={{ cursor: "grab" }}
+        onMouseDown={handleRotateMouseDown}
+      />
     </g>
   );
 };

--- a/src/pages/Editor/components/Canvas/Selection.tsx
+++ b/src/pages/Editor/components/Canvas/Selection.tsx
@@ -1,10 +1,14 @@
 import { Shape } from "@/types/shape";
+import { Point } from "@/types/mouse";
 
 interface SelectionProps {
   shape: Shape;
+  onStartResize: (handle: string, point: Point) => void;
 }
 
-export const Selection = ({ shape }: SelectionProps) => {
+const HANDLE_SIZE = 8;
+
+export const Selection = ({ shape, onStartResize }: SelectionProps) => {
   const getBoundingBox = () => {
     switch (shape.type) {
       case "rectangle":
@@ -29,17 +33,51 @@ export const Selection = ({ shape }: SelectionProps) => {
 
   const box = getBoundingBox();
 
-  return (
+  const handleMouseDown = (e: React.MouseEvent, handle: string) => {
+    e.stopPropagation();
+    // SVG 요소의 좌표계로 변환
+    const svg = e.currentTarget.closest("svg");
+    if (!svg) return;
+
+    const svgRect = svg.getBoundingClientRect();
+    const point = {
+      x: e.clientX - svgRect.left,
+      y: e.clientY - svgRect.top,
+    };
+    onStartResize(handle, point);
+  };
+
+  const renderHandle = (position: string, x: number, y: number) => (
     <rect
-      x={box.x - 1}
-      y={box.y - 1}
-      width={box.width + 2}
-      height={box.height + 2}
-      fill="none"
+      x={x - HANDLE_SIZE / 2}
+      y={y - HANDLE_SIZE / 2}
+      width={HANDLE_SIZE}
+      height={HANDLE_SIZE}
+      fill="white"
       stroke="#0B7FFF"
       strokeWidth={1}
-      strokeDasharray="4 4"
-      pointerEvents="none"
+      style={{ cursor: `${position}-resize` }}
+      onMouseDown={(e) => handleMouseDown(e, position)}
     />
+  );
+
+  return (
+    <g>
+      <rect
+        x={box.x - 1}
+        y={box.y - 1}
+        width={box.width + 2}
+        height={box.height + 2}
+        fill="none"
+        stroke="#0B7FFF"
+        strokeWidth={1}
+        strokeDasharray="4 4"
+        pointerEvents="none"
+      />
+      {renderHandle("nw", box.x, box.y)}
+      {renderHandle("ne", box.x + box.width, box.y)}
+      {renderHandle("se", box.x + box.width, box.y + box.height)}
+      {renderHandle("sw", box.x, box.y + box.height)}
+    </g>
   );
 };

--- a/src/pages/Editor/components/Canvas/Selection.tsx
+++ b/src/pages/Editor/components/Canvas/Selection.tsx
@@ -1,0 +1,45 @@
+import { Shape } from "@/types/shape";
+
+interface SelectionProps {
+  shape: Shape;
+}
+
+export const Selection = ({ shape }: SelectionProps) => {
+  const getBoundingBox = () => {
+    switch (shape.type) {
+      case "rectangle":
+        return {
+          x: shape.x,
+          y: shape.y,
+          width: shape.width,
+          height: shape.height,
+        };
+      case "circle":
+      case "polygon": {
+        const size = shape.radius * 2;
+        return {
+          x: shape.x - shape.radius,
+          y: shape.y - shape.radius,
+          width: size,
+          height: size,
+        };
+      }
+    }
+  };
+
+  const box = getBoundingBox();
+
+  return (
+    <rect
+      x={box.x - 1}
+      y={box.y - 1}
+      width={box.width + 2}
+      height={box.height + 2}
+      fill="none"
+      stroke="#0B7FFF"
+      strokeWidth={1}
+      strokeDasharray="4 4"
+      pointerEvents="none"
+    />
+  );
+};

--- a/src/pages/Editor/components/Canvas/shapes/Circle.tsx
+++ b/src/pages/Editor/components/Canvas/shapes/Circle.tsx
@@ -1,0 +1,20 @@
+import { CircleShape } from "@/types/shape";
+
+interface CircleProps {
+  shape: CircleShape;
+}
+
+export const Circle = ({ shape }: CircleProps) => {
+  const { x, y, radius, fill, stroke, strokeWidth } = shape;
+
+  return (
+    <circle
+      cx={x}
+      cy={y}
+      r={radius}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+    />
+  );
+};

--- a/src/pages/Editor/components/Canvas/shapes/Polygon.tsx
+++ b/src/pages/Editor/components/Canvas/shapes/Polygon.tsx
@@ -1,0 +1,20 @@
+import { PolygonShape } from "@/types/shape";
+import { calculatePolygonPoints } from "@/utils/shapeHelpers";
+
+interface PolygonProps {
+  shape: PolygonShape;
+}
+
+export const Polygon = ({ shape }: PolygonProps) => {
+  const { x, y, radius, sides, fill, stroke, strokeWidth } = shape;
+  const points = calculatePolygonPoints(x, y, radius, sides);
+
+  return (
+    <polygon
+      points={points}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+    />
+  );
+};

--- a/src/pages/Editor/components/Canvas/shapes/Rectangle.tsx
+++ b/src/pages/Editor/components/Canvas/shapes/Rectangle.tsx
@@ -1,0 +1,24 @@
+import { RectangleShape } from "@/types/shape";
+
+interface RectangleProps {
+  shape: RectangleShape;
+}
+
+export const Rectangle = ({ shape }: RectangleProps) => {
+  const { x, y, width, height, fill, stroke, strokeWidth, borderRadius } =
+    shape;
+
+  return (
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      rx={borderRadius}
+      ry={borderRadius}
+    />
+  );
+};

--- a/src/pages/Editor/components/Settings/SettingsPanel.tsx
+++ b/src/pages/Editor/components/Settings/SettingsPanel.tsx
@@ -1,6 +1,5 @@
 import { SettingsPanelProps } from "@/types/components/settings";
 import { ColorInput } from "@/components/common/Input/ColorInput";
-import { TextProperties } from "@/pages/Editor/components/Settings/Properties/TextProperties";
 import { CircleProperties } from "@/pages/Editor/components/Settings/Properties/CircleProperties";
 import { RectangleProperties } from "@/pages/Editor/components/Settings/Properties/RectangleProperties";
 import { CursorProperties } from "@/pages/Editor/components/Settings/Properties/CursorProperties";
@@ -21,8 +20,6 @@ export const SettingsPanel = ({
         return <CircleProperties />;
       case "polygon":
         return <PolygonProperties />;
-      case "text":
-        return <TextProperties />;
       default:
         return null;
     }

--- a/src/pages/Editor/components/Tools/ToolPanel.tsx
+++ b/src/pages/Editor/components/Tools/ToolPanel.tsx
@@ -1,13 +1,11 @@
 import { IconButton } from "@/components/common/Button/IconButton";
 import { TOOLS } from "@/constants/icons";
 import { ToolType } from "@/types/components/tools";
+import { useEditorStore } from "@/store/useEditorStore";
 
-interface ToolPanelProps {
-  selectedTool: ToolType | null;
-  onSelectTool: (tool: ToolType) => void;
-}
+export const ToolPanel = () => {
+  const { selectedTool, setSelectedTool } = useEditorStore();
 
-export const ToolPanel = ({ selectedTool, onSelectTool }: ToolPanelProps) => {
   return (
     <div className="flex flex-col gap-2 p-1">
       {TOOLS.map((tool) => (
@@ -15,14 +13,14 @@ export const ToolPanel = ({ selectedTool, onSelectTool }: ToolPanelProps) => {
           key={tool.id}
           icon={
             <tool.icon
-              className={`w-8 h-8 p-2  rounded ${
+              className={`w-8 h-8 p-2 rounded ${
                 selectedTool === tool.id ? "text-white" : ""
               }`}
             />
           }
           title={tool.title}
           className={selectedTool === tool.id ? "bg-black" : ""}
-          onClick={() => onSelectTool(tool.id as ToolType)}
+          onClick={() => setSelectedTool(tool.id as ToolType)}
         />
       ))}
     </div>

--- a/src/pages/Editor/components/Tools/ToolPanel.tsx
+++ b/src/pages/Editor/components/Tools/ToolPanel.tsx
@@ -15,7 +15,7 @@ export const ToolPanel = ({ selectedTool, onSelectTool }: ToolPanelProps) => {
           key={tool.id}
           icon={
             <tool.icon
-              className={`w-5 h-5 p-2  rounded ${
+              className={`w-8 h-8 p-2  rounded ${
                 selectedTool === tool.id ? "text-white" : ""
               }`}
             />

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -206,7 +206,8 @@ export const useEditorStore = create<EditorState>((set) => ({
         !state.resize.isResizing ||
         !state.resize.startPoint ||
         !state.resize.initialShape ||
-        !state.selectedShapeId
+        !state.selectedShapeId ||
+        !state.resize.handle
       ) {
         return state;
       }
@@ -214,6 +215,7 @@ export const useEditorStore = create<EditorState>((set) => ({
       const dx = point.x - state.resize.startPoint.x;
       const dy = point.y - state.resize.startPoint.y;
       const initialShape = state.resize.initialShape;
+      const handle = state.resize.handle;
 
       return {
         ...state,
@@ -221,17 +223,41 @@ export const useEditorStore = create<EditorState>((set) => ({
           if (shape.id !== state.selectedShapeId) return shape;
 
           if (shape.type === "rectangle" && initialShape.type === "rectangle") {
-            const width = Math.max(10, initialShape.width + dx);
-            const height = Math.max(10, initialShape.height + dy);
-            return { ...shape, width, height };
+            let width = initialShape.width;
+            let height = initialShape.height;
+            let x = initialShape.x;
+            let y = initialShape.y;
+
+            switch (handle) {
+              case "se":
+                width = Math.max(10, initialShape.width + dx);
+                height = Math.max(10, initialShape.height + dy);
+                break;
+              case "sw":
+                width = Math.max(10, initialShape.width - dx);
+                height = Math.max(10, initialShape.height + dy);
+                x = initialShape.x + dx;
+                break;
+              case "ne":
+                width = Math.max(10, initialShape.width + dx);
+                height = Math.max(10, initialShape.height - dy);
+                y = initialShape.y + dy;
+                break;
+              case "nw":
+                width = Math.max(10, initialShape.width - dx);
+                height = Math.max(10, initialShape.height - dy);
+                x = initialShape.x + dx;
+                y = initialShape.y + dy;
+                break;
+            }
+
+            return { ...shape, x, y, width, height };
           }
 
-          if (shape.type === "circle" && initialShape.type === "circle") {
-            const radius = Math.max(10, initialShape.radius + Math.max(dx, dy));
-            return { ...shape, radius };
-          }
-
-          if (shape.type === "polygon" && initialShape.type === "polygon") {
+          if (
+            (shape.type === "circle" || shape.type === "polygon") &&
+            initialShape.type === shape.type
+          ) {
             const radius = Math.max(10, initialShape.radius + Math.max(dx, dy));
             return { ...shape, radius };
           }

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+import { Shape, CreateShapeProps, ShapeType } from "@/types/shape";
+import { createShape } from "@/utils/shapeFactory";
+
+interface EditorState {
+  shapes: Shape[];
+  selectedShapeId: string | null;
+  selectedTool: ShapeType | "cursor";
+  isDragging: boolean;
+
+  addShape: (props: CreateShapeProps) => void;
+  updateShape: <T extends Shape>(
+    id: string,
+    updates: Partial<Omit<T, "id" | "type">>
+  ) => void;
+  deleteShape: (id: string) => void;
+  selectShape: (id: string | null) => void;
+  setSelectedTool: (tool: ShapeType | "cursor") => void;
+  setIsDragging: (isDragging: boolean) => void;
+}
+
+export const useEditorStore = create<EditorState>((set) => ({
+  shapes: [],
+  selectedShapeId: null,
+  selectedTool: "cursor",
+  isDragging: false,
+
+  addShape: (props) =>
+    set((state) => ({
+      shapes: [...state.shapes, createShape(props)],
+    })),
+
+  updateShape: (id, updates) =>
+    set((state) => ({
+      ...state,
+      shapes: state.shapes.map((shape) =>
+        shape.id === id
+          ? {
+              ...shape,
+              ...(updates as Partial<Omit<typeof shape, "id" | "type">>),
+            }
+          : shape
+      ),
+    })),
+
+  deleteShape: (id) =>
+    set((state) => ({
+      shapes: state.shapes.filter((shape) => shape.id !== id),
+      selectedShapeId:
+        state.selectedShapeId === id ? null : state.selectedShapeId,
+    })),
+
+  selectShape: (id) =>
+    set({
+      selectedShapeId: id,
+    }),
+
+  setSelectedTool: (tool) =>
+    set({
+      selectedTool: tool,
+    }),
+
+  setIsDragging: (isDragging) =>
+    set({
+      isDragging,
+    }),
+}));

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,12 +1,14 @@
 import { create } from "zustand";
 import { Shape, CreateShapeProps, ShapeType } from "@/types/shape";
 import { createShape } from "@/utils/shapeFactory";
+import { MouseState, Point } from "@/types/mouse";
 
 interface EditorState {
   shapes: Shape[];
   selectedShapeId: string | null;
   selectedTool: ShapeType | "cursor";
   isDragging: boolean;
+  mouse: MouseState;
 
   addShape: (props: CreateShapeProps) => void;
   updateShape: <T extends Shape>(
@@ -17,6 +19,9 @@ interface EditorState {
   selectShape: (id: string | null) => void;
   setSelectedTool: (tool: ShapeType | "cursor") => void;
   setIsDragging: (isDragging: boolean) => void;
+  startDrawing: (point: Point) => void;
+  updateDrawing: (point: Point) => void;
+  endDrawing: () => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -24,6 +29,11 @@ export const useEditorStore = create<EditorState>((set) => ({
   selectedShapeId: null,
   selectedTool: "cursor",
   isDragging: false,
+  mouse: {
+    isDrawing: false,
+    startPoint: null,
+    endPoint: null,
+  },
 
   addShape: (props) =>
     set((state) => ({
@@ -64,4 +74,33 @@ export const useEditorStore = create<EditorState>((set) => ({
     set({
       isDragging,
     }),
+
+  startDrawing: (point) =>
+    set((state) => ({
+      ...state,
+      mouse: {
+        isDrawing: true,
+        startPoint: point,
+        endPoint: point,
+      },
+    })),
+
+  updateDrawing: (point) =>
+    set((state) => ({
+      ...state,
+      mouse: {
+        ...state.mouse,
+        endPoint: point,
+      },
+    })),
+
+  endDrawing: () =>
+    set((state) => ({
+      ...state,
+      mouse: {
+        isDrawing: false,
+        startPoint: null,
+        endPoint: null,
+      },
+    })),
 }));

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,12 +1,13 @@
 import { create } from "zustand";
-import { Shape, CreateShapeProps, ShapeType } from "@/types/shape";
+import { Shape, CreateShapeProps } from "@/types/shape";
 import { createShape } from "@/utils/shapeFactory";
 import { MouseState, Point } from "@/types/mouse";
+import { ToolType } from "@/types/components/tools";
 
 interface EditorState {
   shapes: Shape[];
   selectedShapeId: string | null;
-  selectedTool: ShapeType | "cursor";
+  selectedTool: ToolType;
   isDragging: boolean;
   mouse: MouseState;
 
@@ -17,7 +18,7 @@ interface EditorState {
   ) => void;
   deleteShape: (id: string) => void;
   selectShape: (id: string | null) => void;
-  setSelectedTool: (tool: ShapeType | "cursor") => void;
+  setSelectedTool: (tool: ToolType) => void;
   setIsDragging: (isDragging: boolean) => void;
   startDrawing: (point: Point) => void;
   updateDrawing: (point: Point) => void;
@@ -66,9 +67,10 @@ export const useEditorStore = create<EditorState>((set) => ({
     }),
 
   setSelectedTool: (tool) =>
-    set({
+    set((state) => ({
+      ...state,
       selectedTool: tool,
-    }),
+    })),
 
   setIsDragging: (isDragging) =>
     set({

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand";
-import { Shape, CreateShapeProps } from "@/types/shape";
-import { createShape } from "@/utils/shapeFactory";
+import { Shape } from "@/types/shape";
+
 import { MouseState, Point } from "@/types/mouse";
 import { ToolType } from "@/types/components/tools";
+import { nanoid } from "nanoid";
 
 interface EditorState {
   shapes: Shape[];
@@ -11,7 +12,7 @@ interface EditorState {
   isDragging: boolean;
   mouse: MouseState;
 
-  addShape: (props: CreateShapeProps) => void;
+  addShape: (shape: Shape) => void;
   updateShape: <T extends Shape>(
     id: string,
     updates: Partial<Omit<T, "id" | "type">>
@@ -36,9 +37,10 @@ export const useEditorStore = create<EditorState>((set) => ({
     endPoint: null,
   },
 
-  addShape: (props) =>
+  addShape: (shape) =>
     set((state) => ({
-      shapes: [...state.shapes, createShape(props)],
+      ...state,
+      shapes: [...state.shapes, { ...shape, id: nanoid() }],
     })),
 
   updateShape: (id, updates) =>

--- a/src/types/components/tools.ts
+++ b/src/types/components/tools.ts
@@ -1,4 +1,6 @@
-export type ToolType = "cursor" | "rectangle" | "circle" | "polygon" | "text";
+import { ShapeType } from "../shape";
+
+export type ToolType = ShapeType | "cursor";
 
 interface BaseToolSettings {
   fill: string;

--- a/src/types/mouse.ts
+++ b/src/types/mouse.ts
@@ -1,0 +1,10 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface MouseState {
+  isDrawing: boolean;
+  startPoint: Point | null;
+  endPoint: Point | null;
+}

--- a/src/types/shape.ts
+++ b/src/types/shape.ts
@@ -1,0 +1,43 @@
+export type ShapeType = "rectangle" | "circle" | "polygon";
+
+interface BaseShape {
+  id: string;
+  type: ShapeType;
+  x: number;
+  y: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  rotation: number;
+}
+
+export interface RectangleShape extends BaseShape {
+  type: "rectangle";
+  width: number;
+  height: number;
+  borderRadius: number;
+}
+
+export interface CircleShape extends BaseShape {
+  type: "circle";
+  radius: number;
+  startAngle: number;
+  endAngle: number;
+}
+
+export interface PolygonShape extends BaseShape {
+  type: "polygon";
+  radius: number;
+  sides: number;
+}
+
+export type Shape = RectangleShape | CircleShape | PolygonShape;
+
+export type ShapeStyles = Omit<BaseShape, "id" | "type" | "x" | "y">;
+
+export interface CreateShapeProps {
+  type: ShapeType;
+  x: number;
+  y: number;
+  styles: ShapeStyles;
+}

--- a/src/utils/shapeCalculator.ts
+++ b/src/utils/shapeCalculator.ts
@@ -1,0 +1,42 @@
+import { Point } from "@/types/mouse";
+import { ShapeType } from "@/types/shape";
+
+interface CalculateShapeProps {
+  startPoint: Point;
+  endPoint: Point;
+  type: ShapeType;
+}
+
+export const calculateShapeDimensions = ({
+  startPoint,
+  endPoint,
+  type,
+}: CalculateShapeProps) => {
+  const width = Math.abs(endPoint.x - startPoint.x);
+  const height = Math.abs(endPoint.y - startPoint.y);
+
+  switch (type) {
+    case "rectangle": {
+      const x = Math.min(startPoint.x, endPoint.x);
+      const y = Math.min(startPoint.y, endPoint.y);
+      return { x, y, width, height };
+    }
+
+    case "circle": {
+      const radius = Math.sqrt(width * width + height * height) / 2;
+      const x = startPoint.x + (endPoint.x - startPoint.x) / 2;
+      const y = startPoint.y + (endPoint.y - startPoint.y) / 2;
+      return { x, y, radius };
+    }
+
+    case "polygon": {
+      const x = startPoint.x + (endPoint.x - startPoint.x) / 2;
+      const y = startPoint.y + (endPoint.y - startPoint.y) / 2;
+      const radius = Math.sqrt(width * width + height * height) / 2;
+      return { x, y, radius };
+    }
+
+    default:
+      throw new Error(`알 수 없는 도형 타입: ${type}`);
+  }
+};

--- a/src/utils/shapeFactory.ts
+++ b/src/utils/shapeFactory.ts
@@ -1,0 +1,57 @@
+import { nanoid } from "nanoid";
+import {
+  Shape,
+  CreateShapeProps,
+  RectangleShape,
+  CircleShape,
+  PolygonShape,
+} from "@/types/shape";
+
+const createRectangle = ({
+  x,
+  y,
+  styles,
+}: CreateShapeProps): RectangleShape => ({
+  id: nanoid(),
+  type: "rectangle",
+  x,
+  y,
+  width: 100,
+  height: 100,
+  borderRadius: 0,
+  ...styles,
+});
+
+const createCircle = ({ x, y, styles }: CreateShapeProps): CircleShape => ({
+  id: nanoid(),
+  type: "circle",
+  x,
+  y,
+  radius: 50,
+  startAngle: 0,
+  endAngle: Math.PI * 2,
+  ...styles,
+});
+
+const createPolygon = ({ x, y, styles }: CreateShapeProps): PolygonShape => ({
+  id: nanoid(),
+  type: "polygon",
+  x,
+  y,
+  radius: 50,
+  sides: 3,
+  ...styles,
+});
+
+export const createShape = (props: CreateShapeProps): Shape => {
+  switch (props.type) {
+    case "rectangle":
+      return createRectangle(props);
+    case "circle":
+      return createCircle(props);
+    case "polygon":
+      return createPolygon(props);
+    default:
+      throw new Error(`알수 없는 타입 :  ${props.type}`);
+  }
+};

--- a/src/utils/shapeHelpers.ts
+++ b/src/utils/shapeHelpers.ts
@@ -1,3 +1,6 @@
+import { Point } from "@/types/mouse";
+import { Shape } from "@/types/shape";
+
 export const calculatePolygonPoints = (
   centerX: number,
   centerY: number,
@@ -15,4 +18,27 @@ export const calculatePolygonPoints = (
   }
 
   return points.join(" ");
+};
+
+export const isPointInShape = (point: Point, shape: Shape): boolean => {
+  switch (shape.type) {
+    case "rectangle": {
+      return (
+        point.x >= shape.x &&
+        point.x <= shape.x + shape.width &&
+        point.y >= shape.y &&
+        point.y <= shape.y + shape.height
+      );
+    }
+    case "circle": {
+      const dx = point.x - shape.x;
+      const dy = point.y - shape.y;
+      return dx * dx + dy * dy <= shape.radius * shape.radius;
+    }
+    case "polygon": {
+      const dx = point.x - shape.x;
+      const dy = point.y - shape.y;
+      return dx * dx + dy * dy <= shape.radius * shape.radius;
+    }
+  }
 };

--- a/src/utils/shapeHelpers.ts
+++ b/src/utils/shapeHelpers.ts
@@ -1,0 +1,18 @@
+export const calculatePolygonPoints = (
+  centerX: number,
+  centerY: number,
+  radius: number,
+  sides: number
+): string => {
+  const points: string[] = [];
+  const angleStep = (Math.PI * 2) / sides;
+
+  for (let i = 0; i < sides; i++) {
+    const angle = i * angleStep - Math.PI / 2; // -90도에서 시작
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
+    points.push(`${x},${y}`);
+  }
+
+  return points.join(" ");
+};

--- a/src/utils/shapeHelpers.ts
+++ b/src/utils/shapeHelpers.ts
@@ -1,5 +1,9 @@
+import { Circle } from "@/pages/Editor/components/Canvas/shapes/Circle";
+import { Polygon } from "@/pages/Editor/components/Canvas/shapes/Polygon";
+import { Rectangle } from "@/pages/Editor/components/Canvas/shapes/Rectangle";
 import { Point } from "@/types/mouse";
 import { Shape } from "@/types/shape";
+import { ComponentType } from "react";
 
 export const calculatePolygonPoints = (
   centerX: number,
@@ -41,4 +45,13 @@ export const isPointInShape = (point: Point, shape: Shape): boolean => {
       return dx * dx + dy * dy <= shape.radius * shape.radius;
     }
   }
+};
+
+export const shapeComponentsMapper: Record<
+  Shape["type"],
+  ComponentType<{ shape: Shape }>
+> = {
+  rectangle: Rectangle as ComponentType<{ shape: Shape }>,
+  circle: Circle as ComponentType<{ shape: Shape }>,
+  polygon: Polygon as ComponentType<{ shape: Shape }>,
 };


### PR DESCRIPTION
# TODO
- [x] 도형 생성
- [x] 사각형, 원, 다각형 생성
- [x] 드래그를 통해 생성
- [x] 프리뷰
- [x] 선택된 도형 시각적으로 표시 (파란색 점선 테두리)
- [x] 선택된 도형 이동
- [x] 모서리로 크기 조절

# 진행하면서 고민했던 사항
1. 도형 생성 및 프리뷰
문제: 드래그하는 동안 실시간으로 도형 크기를 계산하고 미리보기를 보여줘야 함
해결:
calculateShapeDimensions 유틸리티 함수로 도형별 크기 계산 로직 분리
Preview 컴포넌트에서 renderShape 함수 재사용하여 일관된 렌더링 보장

2. 상태 관리 구조
문제: 여러 상태(선택, 드래그, 크기 조절)이 서로 영향을 미침
해결:
Zustand store에서 명확한 상태 구조 정의
각 상태별로 독립적인 업데이트 로직 구현
추후 방안 : 현재 하나의 상태에서 관리하는 것을 관심사에 따라 분리되면서 서로 파일에 의존성을 갖지 않게하기
shapeStore, selectionStore, interactionStore

